### PR TITLE
Update Manifest to support Case Sensitive Filesystems

### DIFF
--- a/Kisekae/manifest.json
+++ b/Kisekae/manifest.json
@@ -10,6 +10,6 @@
   "MinimumApiVersion": "2.0",
   "Description": "Modified version (works with SDV 1.3) of GetDressed which that lets you edit your character's appearance.",
   "UniqueID": "Kabigon.kisekae",
-  "EntryDll": "kisekae.dll",
+  "EntryDll": "Kisekae.dll",
   "UpdateKeys": ["Nexus:2348"]
 }


### PR DESCRIPTION
This PR resolves #1 

The `EntryDll` entry on the manifest was referencing the `Kisekae.dll` file incorrectly as `kisekae.dll` this meant SMAPI would fail to load the mod due to being unable to find the file on case-sensitive filesystems such as those commonly used in Linux.

I have updated this entry within the manifest to correctly reference the generated filename.